### PR TITLE
Igb ptp features porting

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -1059,16 +1059,16 @@ class SignallingTLV {
 	 */
 	SignallingTLV() {
 		tlvType = PLAT_htons(0x3);
-		lengthField = PLAT_htons(28);
+		lengthField = PLAT_htons(12);
 		organizationId[0] = '\x00';
 		organizationId[1] = '\x80';
 		organizationId[2] = '\xC2';
 		organizationSubType_ms = 0;
-		organizationSubType_ls = PLAT_htons(1);
+		organizationSubType_ls = PLAT_htons(2);
 		linkDelayInterval = 0;
 		timeSyncInterval = 0;
 		announceInterval = 0;
-		flags = 0;
+		flags = 3;
 		reserved = PLAT_htons(0);
 	}
 

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -1139,6 +1139,12 @@ class IEEE1588Port {
 	void timestamper_init(void);
 
 	/**
+	 * @brief Resets the hwtimestamper
+	 */
+	void timestamper_reset(void);
+
+
+	/**
 	 * @brief  Gets RX timestamp based on port identity
 	 * @param  sourcePortIdentity [in] Source port identity
 	 * @param  sequenceId Sequence ID

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -478,6 +478,13 @@ public:
 		{ return true; }
 
 	/**
+	 * @brief Reset the hardware timestamp unit
+	 * @return void
+	 */
+	virtual void HWTimestamper_reset(void) {
+	}
+
+	/**
 	 * @brief  This method is called before the object is de-allocated.
 	 * @return void
 	 */

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -424,6 +424,9 @@ bool IEEE1588Clock::isBetterThan(PTPMessageAnnounce * msg)
 	unsigned char that1[14];
 	uint16_t tmp;
 
+	if (msg == NULL)
+		return true;
+
 	this1[0] = priority1;
 	that1[0] = msg->getGrandmasterPriority1();
 

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -207,6 +207,14 @@ void IEEE1588Port::timestamper_init(void)
 	}
 }
 
+void IEEE1588Port::timestamper_reset(void)
+{
+	if( _hw_timestamper != NULL ) {
+		_hw_timestamper->init_phy_delay(this->link_delay);
+		_hw_timestamper->HWTimestamper_reset();
+	}
+}
+
 bool IEEE1588Port::init_port(int delay[4])
 {
 	if (!OSNetworkInterfaceFactory::buildInterface
@@ -764,7 +772,7 @@ void IEEE1588Port::processEvent(Event e)
 				linkUpCount++;
 			}
 		}
-		this->timestamper_init();
+		this->timestamper_reset();
 		break;
 
 	case LINKDOWN:

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -582,7 +582,7 @@ void IEEE1588Port::processEvent(Event e)
 				// Send an initial signalling message
 				PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
 				if (sigMsg) {
-					sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
+					sigMsg->setintervals(PTPMessageSignalling::sigMsgInterval_NoSend, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
 					sigMsg->sendPort(this, NULL);
 					delete sigMsg;
 				}
@@ -617,11 +617,15 @@ void IEEE1588Port::processEvent(Event e)
 					}
 					if (EBest == NULL) {
 						EBest = ports[j]->calculateERBest();
-					} else {
+					} else if (ports[j]->calculateERBest()) {
 						if (ports[j]->calculateERBest()->isBetterThan(EBest)) {
 							EBest = ports[j]->calculateERBest();
 						}
 					}
+				}
+
+				if (EBest == NULL) {
+					break;
 				}
 
 				/* Check if we've changed */
@@ -732,7 +736,7 @@ void IEEE1588Port::processEvent(Event e)
 				// Send an initial signaling message
 				PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
 				if (sigMsg) {
-					sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
+					sigMsg->setintervals(PTPMessageSignalling::sigMsgInterval_NoSend, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
 					sigMsg->sendPort(this, NULL);
 					delete sigMsg;
 				}
@@ -1202,7 +1206,10 @@ void IEEE1588Port::processEvent(Event e)
 				// Send operational signalling message
 					PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
 					if (sigMsg) {
-						sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
+						if (automotive_profile)
+							sigMsg->setintervals(PTPMessageSignalling::sigMsgInterval_NoChange, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
+						else 
+							sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
 						sigMsg->sendPort(this, NULL);
 						delete sigMsg;
 					}

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -407,6 +407,9 @@ PTPMessageCommon *buildPTPMessage
 		}
 		break;
 	case ANNOUNCE_MESSAGE:
+
+		GPTP_LOG_VERBOSE("*** Received Announce message");
+
 		{
 			PTPMessageAnnounce *annc = new PTPMessageAnnounce();
 			annc->messageType = messageType;
@@ -933,7 +936,7 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	FrequencyRatio local_clock_adjustment;
 	FrequencyRatio local_system_freq_offset;
 	FrequencyRatio master_local_freq_offset;
-	int correction;
+	int64_t correction;
 	int32_t scaledLastGmFreqChange = 0;
 	scaledNs scaledLastGmPhaseChange;
 
@@ -989,13 +992,12 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	}
 
 	master_local_freq_offset  =  tlv.getRateOffset();
-	master_local_freq_offset /= 2ULL << 41;
+	master_local_freq_offset /= 1ULL << 41;
 	master_local_freq_offset += 1.0;
 	master_local_freq_offset /= port->getPeerRateOffset();
 
-	correctionField = (uint64_t)
-		((correctionField >> 16)/master_local_freq_offset);
-	correction = (int) (delay + correctionField);
+	correctionField /= 1 << 16;
+	correction = (int64_t)((delay * master_local_freq_offset) + correctionField );
 
 	if( correction > 0 )
 	  TIMESTAMP_ADD_NS( preciseOriginTimestamp, correction );
@@ -1040,8 +1042,13 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	port->getClock()->getFUPStatus()->setScaledLastGmFreqChange( scaledLastGmFreqChange );
 	port->getClock()->getFUPStatus()->setScaledLastGmPhaseChange( scaledLastGmPhaseChange );
 
-	if( port->getPortState() != PTP_MASTER ) {
+	if( port->getPortState() == PTP_SLAVE )
+	{
+		/* The sync_count counts the number of sync messages received
+		   that influence the time on the device. Since adjustments are only
+		   made in the PTP_SLAVE state, increment it here */
 		port->incSyncCount();
+
 		/* Do not call calcLocalSystemClockRateDifference it updates state
 		   global to the clock object and if we are master then the network
 		   is transitioning to us not being master but the master process

--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -33,7 +33,20 @@ ALTERNATE_LINUX_INCPATH=$(HOME)/header/include/
 CFLAGS_G = -Wall -std=c++0x -g -I. -I../../common -I../src \
 	-I$(ALTERNATE_LINUX_INCPATH)
 
-CPPFLAGS_G := $(CFLAGS_G) -Wnon-virtual-dtor
+# Check to see if PTP cross-timestamping is supported in hardware/driver
+# and, if so, add flag to compile in support
+
+PRECISE_TIME_TEST = "\#include <linux/ptp_clock.h>\\n\
+\#ifdef PTP_SYS_OFFSET_PRECISE\\nint main(){return 0;}\\n\#endif"
+
+HAS_PRECISE_TIME = $(shell echo $(PRECISE_TIME_TEST) | gcc -xc - \
+-I$(ALTERNATE_LINUX_INCPATH) -o /dev/null > /dev/null 2>&1 ; echo $$?)
+
+ifeq ($(HAS_PRECISE_TIME),0)
+       CFLAGS_G += -DPTP_HW_CROSSTSTAMP
+endif
+
+CPPFLAGS_G = $(CFLAGS_G) -Wnon-virtual-dtor
 
 LDFLAGS_G = -lpthread -lrt
 

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -363,10 +363,6 @@ int main(int argc, char **argv)
 	portInit.lock_factory = lock_factory;
 
 	pPort = new IEEE1588Port(&portInit);
-	if (!pPort->init_port(phy_delay)) {
-		printf("failed to initialize port \n");
-		return -1;
-	}
 
 	if(use_config_file)
 	{
@@ -406,6 +402,11 @@ int main(int argc, char **argv)
 			}
 		}
 
+	}
+
+	if (!pPort->init_port(phy_delay)) {
+		printf("failed to initialize port \n");
+		return -1;
 	}
 
 	if( restoredataptr != NULL ) {

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -269,6 +269,13 @@ bool LinuxTimestamperGeneric::HWTimestamper_init
 	return true;
 }
 
+void LinuxTimestamperGeneric::HWTimestamper_reset()
+{
+	if( !resetFrequencyAdjustment() ) {
+		GPTP_LOG_ERROR( "Failed to reset (zero) frequency adjustment" );
+	}
+}
+
 int LinuxTimestamperGeneric::HWTimestamper_txtimestamp
 ( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
   unsigned &clock_value, bool last ) {

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -103,6 +103,12 @@ public:
 	( InterfaceLabel *iface_label, OSNetworkInterface *iface );
 
 	/**
+	 * @brief  Reset the Hardware timestamp interface
+	 * @return void
+	 */
+	virtual void HWTimestamper_reset();
+
+	/**
 	 * @brief  Inserts a new timestamp to the beginning of the
 	 * RX timestamp list.
 	 * @param tstamp [in] RX timestamp

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -62,6 +62,9 @@ private:
 	bool cross_stamp_good;
 	std::list<Timestamp> rxTimestampList;
 	LinuxNetworkInterfaceList iface_list;
+#ifdef PTP_HW_CROSSTSTAMP
+	bool precise_timestamp_enabled;
+#endif
 
 	TicketingLock *net_lock;
 

--- a/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
+++ b/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
@@ -47,7 +47,8 @@ static bool exit_flag;
 void print_usage( char *arg0 ) {
 	fprintf( stderr,
 		"%s "
-		"[-R <priority 1>] <network interface>\n",
+		"[-R <priority 1>] <network interface>\n"
+		"where <network interface> is a MAC address entered as xx-xx-xx-xx-xx-xx\n",
 		arg0 );
 }
 
@@ -121,8 +122,15 @@ int _tmain(int argc, _TCHAR* argv[])
 		ipc = NULL;
 	}
 
+	// If there are no arguments, output usage
+	if (1 == argc) {
+		print_usage(argv[0]);
+		return -1;
+	}
+
+
 	/* Process optional arguments */
-	for( i = 1; i < argc-1; ++i ) {
+	for( i = 1; i < argc; ++i ) {
 		if( ispunct(argv[i][0]) ) {
 			if( toupper( argv[i][1] ) == 'H' ) {
 				print_usage( argv[0] );
@@ -145,12 +153,11 @@ int _tmain(int argc, _TCHAR* argv[])
 		}
 	}
 
+	// the last argument is supposed to be a MAC address, so decrement argv index to read it
+	i--;
+
 	// Create Low level network interface object
 	uint8_t local_addr_ostr[ETHER_ADDR_OCTETS];
-	if( i >= argc ) {
-		print_usage( argv[0] );
-		return -1;
-	}
 	parseMacAddr( argv[i], local_addr_ostr );
 	LinkLayerAddress local_addr(local_addr_ostr);
 	portInit.net_label = &local_addr;

--- a/daemons/mrpd/mrp.c
+++ b/daemons/mrpd/mrp.c
@@ -665,7 +665,6 @@ int mrp_applicant_fsm(struct mrp_database *mrp_db,
 			optional = 1;
 			tx = 1;
 			sndmsg = MRP_SND_IN;
-			mrp_state = MRP_VO_STATE;
 			break;
 		default:
 			break;

--- a/daemons/mrpd/mrpd.c
+++ b/daemons/mrpd/mrpd.c
@@ -280,6 +280,9 @@ int process_ctl_msg(char *buf, int buflen, struct sockaddr_in *client)
 	 * S+? - JOIN_MT a Stream
 	 * S++ - JOIN_IN a Stream
 	 * S-- - LV a Stream
+	 * I+S   Add a stream id to the interesting talker stream id list
+	 * I-S   Remove a stream id from the interesting talker stream id list
+	 * I-A   Remove all stream ids from the interesting talker and listener stream id lists
 	 *
 	 * Outbound messages
 	 * ERC - error, unrecognized command
@@ -331,6 +334,7 @@ int process_ctl_msg(char *buf, int buflen, struct sockaddr_in *client)
 		return mvrp_recv_cmd(buf, buflen, client);
 		break;
 	case 'S':
+	case 'I':
 		return msrp_recv_cmd(buf, buflen, client);
 		break;
 	case 'B':

--- a/examples/simple_rx/Makefile
+++ b/examples/simple_rx/Makefile
@@ -3,7 +3,8 @@ OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses
 IGBDIR = ../../lib/igb
 INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common -I$(IGBDIR)
-LDLIBS = -lpcap -lsndfile -pthread -lpci
+# GLIBC versions starting with 2.17 don't need -lrt anymore
+LDLIBS = -lpcap -lsndfile -pthread -lpci -lrt
 
 all: simple_rx
 

--- a/kmod/igb/e1000_defines.h
+++ b/kmod/igb/e1000_defines.h
@@ -58,8 +58,10 @@
 #define E1000_CTRL_EXT_LPCD		0x00000004 /* LCD Power Cycle Done */
 #define E1000_CTRL_EXT_SDP4_DATA	0x00000010 /* SW Definable Pin 4 data */
 #define E1000_CTRL_EXT_SDP6_DATA	0x00000040 /* SW Definable Pin 6 data */
+#define E1000_CTRL_EXT_SDP2_DATA	0x00000040 /* SW Definable Pin 2 data */
 #define E1000_CTRL_EXT_SDP3_DATA	0x00000080 /* SW Definable Pin 3 data */
 #define E1000_CTRL_EXT_SDP6_DIR	0x00000400 /* Direction of SDP6 0=in 1=out */
+#define E1000_CTRL_EXT_SDP2_DIR	0x00000400 /* Direction of SDP2 0=in 1=out */
 #define E1000_CTRL_EXT_SDP3_DIR	0x00000800 /* Direction of SDP3 0=in 1=out */
 #define E1000_CTRL_EXT_FORCE_SMBUS	0x00000800 /* Force SMBus mode */
 #define E1000_CTRL_EXT_EE_RST	0x00002000 /* Reinitialize from EEPROM */
@@ -258,6 +260,8 @@
 #define E1000_CTRL_ADVD3WUC	0x00100000 /* D3 WUC */
 #define E1000_CTRL_SWDPIN3	0x00200000 /* SWDPIN 3 value */
 #define E1000_CTRL_SWDPIO0	0x00400000 /* SWDPIN 0 Input or output */
+#define E1000_CTRL_SDP0_DIR	0x00400000  /* SDP0 Data direction */
+#define E1000_CTRL_SDP1_DIR	0x00800000  /* SDP1 Data direction */
 #define E1000_CTRL_RST		0x04000000 /* Global reset */
 #define E1000_CTRL_RFCE		0x08000000 /* Receive Flow Control enable */
 #define E1000_CTRL_TFCE		0x10000000 /* Transmit flow control enable */
@@ -719,8 +723,67 @@
 #define E1000_TIMINCA_INCPERIOD_SHIFT	24
 #define E1000_TIMINCA_INCVALUE_MASK	0x00FFFFFF
 
-#define E1000_TSICR_TXTS		0x00000002
-#define E1000_TSIM_TXTS			0x00000002
+/* Time Sync Interrupt Cause/Mask Register Bits */
+
+#define TSINTR_SYS_WRAP  (1 << 0) /* SYSTIM Wrap around. */
+#define TSINTR_TXTS      (1 << 1) /* Transmit Timestamp. */
+#define TSINTR_RXTS      (1 << 2) /* Receive Timestamp. */
+#define TSINTR_TT0       (1 << 3) /* Target Time 0 Trigger. */
+#define TSINTR_TT1       (1 << 4) /* Target Time 1 Trigger. */
+#define TSINTR_AUTT0     (1 << 5) /* Auxiliary Timestamp 0 Taken. */
+#define TSINTR_AUTT1     (1 << 6) /* Auxiliary Timestamp 1 Taken. */
+#define TSINTR_TADJ      (1 << 7) /* Time Adjust Done. */
+
+#define TSYNC_INTERRUPTS TSINTR_TXTS
+#define E1000_TSICR_TXTS TSINTR_TXTS
+
+/* TSAUXC Configuration Bits */
+#define TSAUXC_EN_TT0    (1 << 0)  /* Enable target time 0. */
+#define TSAUXC_EN_TT1    (1 << 1)  /* Enable target time 1. */
+#define TSAUXC_EN_CLK0   (1 << 2)  /* Enable Configurable Frequency Clock 0. */
+#define TSAUXC_SAMP_AUT0 (1 << 3)  /* Latch SYSTIML/H into AUXSTMPL/0. */
+#define TSAUXC_ST0       (1 << 4)  /* Start Clock 0 Toggle on Target Time 0. */
+#define TSAUXC_EN_CLK1   (1 << 5)  /* Enable Configurable Frequency Clock 1. */
+#define TSAUXC_SAMP_AUT1 (1 << 6)  /* Latch SYSTIML/H into AUXSTMPL/1. */
+#define TSAUXC_ST1       (1 << 7)  /* Start Clock 1 Toggle on Target Time 1. */
+#define TSAUXC_EN_TS0    (1 << 8)  /* Enable hardware timestamp 0. */
+#define TSAUXC_AUTT0     (1 << 9)  /* Auxiliary Timestamp Taken. */
+#define TSAUXC_EN_TS1    (1 << 10) /* Enable hardware timestamp 0. */
+#define TSAUXC_AUTT1     (1 << 11) /* Auxiliary Timestamp Taken. */
+#define TSAUXC_PLSG      (1 << 17) /* Generate a pulse. */
+#define TSAUXC_DISABLE   (1 << 31) /* Disable SYSTIM Count Operation. */
+
+/* SDP Configuration Bits */
+#define AUX0_SEL_SDP0    (0 << 0)  /* Assign SDP0 to auxiliary time stamp 0. */
+#define AUX0_SEL_SDP1    (1 << 0)  /* Assign SDP1 to auxiliary time stamp 0. */
+#define AUX0_SEL_SDP2    (2 << 0)  /* Assign SDP2 to auxiliary time stamp 0. */
+#define AUX0_SEL_SDP3    (3 << 0)  /* Assign SDP3 to auxiliary time stamp 0. */
+#define AUX0_TS_SDP_EN   (1 << 2)  /* Enable auxiliary time stamp trigger 0. */
+#define AUX1_SEL_SDP0    (0 << 3)  /* Assign SDP0 to auxiliary time stamp 1. */
+#define AUX1_SEL_SDP1    (1 << 3)  /* Assign SDP1 to auxiliary time stamp 1. */
+#define AUX1_SEL_SDP2    (2 << 3)  /* Assign SDP2 to auxiliary time stamp 1. */
+#define AUX1_SEL_SDP3    (3 << 3)  /* Assign SDP3 to auxiliary time stamp 1. */
+#define AUX1_TS_SDP_EN   (1 << 5)  /* Enable auxiliary time stamp trigger 1. */
+#define TS_SDP0_SEL_TT0  (0 << 6)  /* Target time 0 is output on SDP0. */
+#define TS_SDP0_SEL_TT1  (1 << 6)  /* Target time 1 is output on SDP0. */
+#define TS_SDP0_SEL_FC0  (2 << 6)  /* Freq clock  0 is output on SDP0. */
+#define TS_SDP0_SEL_FC1  (3 << 6)  /* Freq clock  1 is output on SDP0. */
+#define TS_SDP0_EN       (1 << 8)  /* SDP0 is assigned to Tsync. */
+#define TS_SDP1_SEL_TT0  (0 << 9)  /* Target time 0 is output on SDP1. */
+#define TS_SDP1_SEL_TT1  (1 << 9)  /* Target time 1 is output on SDP1. */
+#define TS_SDP1_SEL_FC0  (2 << 9)  /* Freq clock  0 is output on SDP1. */
+#define TS_SDP1_SEL_FC1  (3 << 9)  /* Freq clock  1 is output on SDP1. */
+#define TS_SDP1_EN       (1 << 11) /* SDP1 is assigned to Tsync. */
+#define TS_SDP2_SEL_TT0  (0 << 12) /* Target time 0 is output on SDP2. */
+#define TS_SDP2_SEL_TT1  (1 << 12) /* Target time 1 is output on SDP2. */
+#define TS_SDP2_SEL_FC0  (2 << 12) /* Freq clock  0 is output on SDP2. */
+#define TS_SDP2_SEL_FC1  (3 << 12) /* Freq clock  1 is output on SDP2. */
+#define TS_SDP2_EN       (1 << 14) /* SDP2 is assigned to Tsync. */
+#define TS_SDP3_SEL_TT0  (0 << 15) /* Target time 0 is output on SDP3. */
+#define TS_SDP3_SEL_TT1  (1 << 15) /* Target time 1 is output on SDP3. */
+#define TS_SDP3_SEL_FC0  (2 << 15) /* Freq clock  0 is output on SDP3. */
+#define TS_SDP3_SEL_FC1  (3 << 15) /* Freq clock  1 is output on SDP3. */
+#define TS_SDP3_EN       (1 << 17) /* SDP3 is assigned to Tsync. */
 /* TUPLE Filtering Configuration */
 #define E1000_TTQF_DISABLE_MASK		0xF0008000 /* TTQF Disable Mask */
 #define E1000_TTQF_QUEUE_ENABLE		0x100   /* TTQF Queue Enable Bit */

--- a/kmod/igb/e1000_regs.h
+++ b/kmod/igb/e1000_regs.h
@@ -534,6 +534,8 @@
 #define E1000_TRGTTIMH0	0x0B648 /* Target Time Register 0 High - RW */
 #define E1000_TRGTTIML1	0x0B64C /* Target Time Register 1 Low  - RW */
 #define E1000_TRGTTIMH1	0x0B650 /* Target Time Register 1 High - RW */
+#define E1000_FREQOUT0	0x0B654 /* Frequency Out 0 Control Register - RW */
+#define E1000_FREQOUT1	0x0B658 /* Frequency Out 1 Control Register - RW */
 #define E1000_AUXSTMPL0	0x0B65C /* Auxiliary Time Stamp 0 Register Low  - RO */
 #define E1000_AUXSTMPH0	0x0B660 /* Auxiliary Time Stamp 0 Register High - RO */
 #define E1000_AUXSTMPL1	0x0B664 /* Auxiliary Time Stamp 1 Register Low  - RO */

--- a/kmod/igb/e1000_regs.h
+++ b/kmod/igb/e1000_regs.h
@@ -51,6 +51,7 @@
 #define E1000_FCT	0x00030  /* Flow Control Type - RW */
 #define E1000_CONNSW	0x00034  /* Copper/Fiber switch control - RW */
 #define E1000_VET	0x00038  /* VLAN Ether Type - RW */
+#define E1000_TSSDP	0x0003C  /* Time Sync SDP Configuration Register - RW */
 #define E1000_ICR	0x000C0  /* Interrupt Cause Read - R/clr */
 #define E1000_ITR	0x000C4  /* Interrupt Throttling Rate - RW */
 #define E1000_ICS	0x000C8  /* Interrupt Cause Set - WO */
@@ -529,11 +530,17 @@
 #define E1000_TIMADJL	0x0B60C /* Time sync time adjustment offset Low - RW */
 #define E1000_TIMADJH	0x0B610 /* Time sync time adjustment offset High - RW */
 #define E1000_TSAUXC	0x0B640 /* Timesync Auxiliary Control register */
+#define E1000_TRGTTIML0	0x0B644 /* Target Time Register 0 Low  - RW */
+#define E1000_TRGTTIMH0	0x0B648 /* Target Time Register 0 High - RW */
+#define E1000_TRGTTIML1	0x0B64C /* Target Time Register 1 Low  - RW */
+#define E1000_TRGTTIMH1	0x0B650 /* Target Time Register 1 High - RW */
+#define E1000_AUXSTMPL0	0x0B65C /* Auxiliary Time Stamp 0 Register Low  - RO */
+#define E1000_AUXSTMPH0	0x0B660 /* Auxiliary Time Stamp 0 Register High - RO */
+#define E1000_AUXSTMPL1	0x0B664 /* Auxiliary Time Stamp 1 Register Low  - RO */
+#define E1000_AUXSTMPH1	0x0B668 /* Auxiliary Time Stamp 1 Register High - RO */
 #define E1000_SYSTIMR	0x0B6F8 /* System time register Residue */
 #define E1000_TSICR	0x0B66C /* Interrupt Cause Register */
 #define E1000_TSIM	0x0B674 /* Interrupt Mask Register */
-#define E1000_AUXSTMPL0 0x0B65C /* Auxiliary Time Stamp 0 Reg - Low */
-#define E1000_AUXSTMPH0 0x0B660 /* Auxiliary Time Stamp 0 Reg - Low */
 
 /* Filtering Registers */
 #define E1000_SAQF(_n)	(0x05980 + (4 * (_n))) /* Source Address Queue Fltr */

--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -663,7 +663,9 @@ struct igb_adapter {
 	u32 tx_hwtstamp_timeouts;
 	u32 rx_hwtstamp_cleared;
 
+#ifdef HAVE_PTP_1588_CLOCK_PINS
 	struct ptp_pin_desc sdp_config[IGB_N_SDP];
+#endif /* HAVE_PTP_1588_CLOCK_PINS */
 	struct {
 		struct timespec64 start;
 		struct timespec64 period;

--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -514,6 +514,9 @@ struct hwmon_buff {
 	unsigned int n_hwmon;
 	};
 #endif /* IGB_HWMON */
+#define IGB_N_EXTTS	2
+#define IGB_N_PEROUT	2
+#define IGB_N_SDP	4
 #ifdef ETHTOOL_GRXFHINDIR
 #define IGB_RETA_SIZE	128
 #endif /* ETHTOOL_GRXFHINDIR */
@@ -659,6 +662,12 @@ struct igb_adapter {
 	struct timecounter tc;
 	u32 tx_hwtstamp_timeouts;
 	u32 rx_hwtstamp_cleared;
+
+	struct ptp_pin_desc sdp_config[IGB_N_SDP];
+	struct {
+		struct timespec start;
+		struct timespec period;
+	} perout[IGB_N_PEROUT];
 #endif /* HAVE_PTP_1588_CLOCK */
 
 #ifdef HAVE_I2C_SUPPORT

--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -665,8 +665,8 @@ struct igb_adapter {
 
 	struct ptp_pin_desc sdp_config[IGB_N_SDP];
 	struct {
-		struct timespec start;
-		struct timespec period;
+		struct timespec64 start;
+		struct timespec64 period;
 	} perout[IGB_N_PEROUT];
 #endif /* HAVE_PTP_1588_CLOCK */
 

--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -575,7 +575,6 @@ struct igb_adapter {
 	/* OS defined structs */
 	struct pci_dev *pdev;
 	/* user-dma specific variables */
-	struct igb_user_page	*userpages;
 	u32	uring_tx_init;
 	u32	uring_rx_init;
 #ifndef HAVE_NETDEV_STATS_IN_NETDEV
@@ -893,6 +892,15 @@ struct igb_link_cmd {
 	u32		up;
 	u32		speed;
 	u32		duplex;
+};
+
+struct igb_private_data {
+	struct igb_adapter *adapter;
+	/* user-dma specific variable for buffer */
+	struct igb_user_page *userpages;
+	/* user-dma specific variable for TX and RX */
+	u32	uring_tx_init;
+	u32	uring_rx_init;
 };
 
 #endif /* _IGB_H_ */

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -10542,7 +10542,7 @@ static int igb_open_file(struct inode *inode, struct file *file)
        struct igb_private_data *igb_priv = NULL;
        int ret = 0;
 
-       igb_priv = kzalloc(sizeof(struct igb_private_data *), GFP_KERNEL);
+       igb_priv = kzalloc(sizeof(struct igb_private_data), GFP_KERNEL);
        if (igb_priv == NULL) {
                ret = -ENOMEM;
                goto out;

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -6053,7 +6053,7 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	struct ptp_clock_event event;
-	struct timespec ts;
+	struct timespec64 ts;
 	u32 ack = 0, tsauxc, sec, nsec, tsicr = rd32(E1000_TSICR);
 
 	if (tsicr & TSINTR_SYS_WRAP) {
@@ -6073,10 +6073,11 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 
 	if (tsicr & TSINTR_TT0) {
 		spin_lock(&adapter->tmreg_lock);
-		ts = timespec_add(adapter->perout[0].start,
-				  adapter->perout[0].period);
+		ts = timespec64_add(adapter->perout[0].start,
+				    adapter->perout[0].period);
+		/* u32 conversion of tv_sec is safe until y2106 */
 		wr32(E1000_TRGTTIML0, ts.tv_nsec);
-		wr32(E1000_TRGTTIMH0, ts.tv_sec);
+		wr32(E1000_TRGTTIMH0, (u32)ts.tv_sec);
 		tsauxc = rd32(E1000_TSAUXC);
 		tsauxc |= TSAUXC_EN_TT0;
 		wr32(E1000_TSAUXC, tsauxc);
@@ -6087,10 +6088,10 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 
 	if (tsicr & TSINTR_TT1) {
 		spin_lock(&adapter->tmreg_lock);
-		ts = timespec_add(adapter->perout[1].start,
-				  adapter->perout[1].period);
+		ts = timespec64_add(adapter->perout[1].start,
+				    adapter->perout[1].period);
 		wr32(E1000_TRGTTIML1, ts.tv_nsec);
-		wr32(E1000_TRGTTIMH1, ts.tv_sec);
+		wr32(E1000_TRGTTIMH1, (u32)ts.tv_sec);
 		tsauxc = rd32(E1000_TSAUXC);
 		tsauxc |= TSAUXC_EN_TT1;
 		wr32(E1000_TSAUXC, tsauxc);

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -6054,7 +6054,7 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 	struct e1000_hw *hw = &adapter->hw;
 	struct ptp_clock_event event;
 	struct timespec64 ts;
-	u32 ack = 0, tsauxc, sec, nsec, tsicr = rd32(E1000_TSICR);
+	u32 ack = 0, tsauxc, sec, nsec, tsicr = E1000_READ_REG(hw, E1000_TSICR);
 
 	if (tsicr & TSINTR_SYS_WRAP) {
 		event.type = PTP_CLOCK_PPS;
@@ -6076,11 +6076,11 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 		ts = timespec64_add(adapter->perout[0].start,
 				    adapter->perout[0].period);
 		/* u32 conversion of tv_sec is safe until y2106 */
-		wr32(E1000_TRGTTIML0, ts.tv_nsec);
-		wr32(E1000_TRGTTIMH0, (u32)ts.tv_sec);
-		tsauxc = rd32(E1000_TSAUXC);
+		E1000_WRITE_REG(hw, E1000_TRGTTIML0, ts.tv_nsec);
+		E1000_WRITE_REG(hw, E1000_TRGTTIMH0, (u32)ts.tv_sec);
+		tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
 		tsauxc |= TSAUXC_EN_TT0;
-		wr32(E1000_TSAUXC, tsauxc);
+		E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc);
 		adapter->perout[0].start = ts;
 		spin_unlock(&adapter->tmreg_lock);
 		ack |= TSINTR_TT0;
@@ -6090,19 +6090,19 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 		spin_lock(&adapter->tmreg_lock);
 		ts = timespec64_add(adapter->perout[1].start,
 				    adapter->perout[1].period);
-		wr32(E1000_TRGTTIML1, ts.tv_nsec);
-		wr32(E1000_TRGTTIMH1, (u32)ts.tv_sec);
-		tsauxc = rd32(E1000_TSAUXC);
+		E1000_WRITE_REG(hw, E1000_TRGTTIML1, ts.tv_nsec);
+		E1000_WRITE_REG(hw, E1000_TRGTTIMH1, (u32)ts.tv_sec);
+		tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
 		tsauxc |= TSAUXC_EN_TT1;
-		wr32(E1000_TSAUXC, tsauxc);
+		E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc);
 		adapter->perout[1].start = ts;
 		spin_unlock(&adapter->tmreg_lock);
 		ack |= TSINTR_TT1;
 	}
 
 	if (tsicr & TSINTR_AUTT0) {
-		nsec = rd32(E1000_AUXSTMPL0);
-		sec  = rd32(E1000_AUXSTMPH0);
+		nsec = E1000_READ_REG(hw, E1000_AUXSTMPL0);
+		sec  = E1000_READ_REG(hw, E1000_AUXSTMPH0);
 		event.type = PTP_CLOCK_EXTTS;
 		event.index = 0;
 		event.timestamp = sec * 1000000000ULL + nsec;
@@ -6111,8 +6111,8 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 	}
 
 	if (tsicr & TSINTR_AUTT1) {
-		nsec = rd32(E1000_AUXSTMPL1);
-		sec  = rd32(E1000_AUXSTMPH1);
+		nsec = E1000_READ_REG(hw, E1000_AUXSTMPL1);
+		sec  = E1000_READ_REG(hw, E1000_AUXSTMPH1);
 		event.type = PTP_CLOCK_EXTTS;
 		event.index = 1;
 		event.timestamp = sec * 1000000000ULL + nsec;
@@ -6121,7 +6121,7 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 	}
 
 	/* acknowledge the interrupts */
-	wr32(E1000_TSICR, ack);
+	E1000_WRITE_REG(hw, E1000_TSICR, ack);
 }
 
 static irqreturn_t igb_msix_other(int irq, void *data)

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -6049,6 +6049,19 @@ void igb_update_stats(struct igb_adapter *adapter)
 	}
 }
 
+static void igb_tsync_interrupt(struct igb_adapter *adapter)
+{
+	struct e1000_hw *hw = &adapter->hw;
+	u32 tsicr = rd32(E1000_TSICR);
+
+	if (tsicr & E1000_TSICR_TXTS) {
+		/* acknowledge the interrupt */
+		wr32(E1000_TSICR, E1000_TSICR_TXTS);
+		/* retrieve hardware timestamp */
+		schedule_work(&adapter->ptp_tx_work);
+	}
+}
+
 static irqreturn_t igb_msix_other(int irq, void *data)
 {
 	struct igb_adapter *adapter = data;
@@ -6081,16 +6094,8 @@ static irqreturn_t igb_msix_other(int irq, void *data)
 	}
 
 #ifdef HAVE_PTP_1588_CLOCK
-	if (icr & E1000_ICR_TS) {
-		u32 tsicr = E1000_READ_REG(hw, E1000_TSICR);
-
-		if (tsicr & E1000_TSICR_TXTS) {
-			/* acknowledge the interrupt */
-			E1000_WRITE_REG(hw, E1000_TSICR, E1000_TSICR_TXTS);
-			/* retrieve hardware timestamp */
-			schedule_work(&adapter->ptp_tx_work);
-		}
-	}
+	if (icr & E1000_ICR_TS)
+		igb_tsync_interrupt(adapter);
 #endif /* HAVE_PTP_1588_CLOCK */
 
 	/* Check for MDD event */
@@ -6999,16 +7004,8 @@ static irqreturn_t igb_intr_msi(int irq, void *data)
 	}
 
 #ifdef HAVE_PTP_1588_CLOCK
-	if (icr & E1000_ICR_TS) {
-		u32 tsicr = E1000_READ_REG(hw, E1000_TSICR);
-
-		if (tsicr & E1000_TSICR_TXTS) {
-			/* acknowledge the interrupt */
-			E1000_WRITE_REG(hw, E1000_TSICR, E1000_TSICR_TXTS);
-			/* retrieve hardware timestamp */
-			schedule_work(&adapter->ptp_tx_work);
-		}
-	}
+	if (icr & E1000_ICR_TS)
+		igb_tsync_interrupt(adapter);
 #endif /* HAVE_PTP_1588_CLOCK */
 
 	napi_schedule(&q_vector->napi);
@@ -7055,16 +7052,8 @@ static irqreturn_t igb_intr(int irq, void *data)
 	}
 
 #ifdef HAVE_PTP_1588_CLOCK
-	if (icr & E1000_ICR_TS) {
-		u32 tsicr = E1000_READ_REG(hw, E1000_TSICR);
-
-		if (tsicr & E1000_TSICR_TXTS) {
-			/* acknowledge the interrupt */
-			E1000_WRITE_REG(hw, E1000_TSICR, E1000_TSICR_TXTS);
-			/* retrieve hardware timestamp */
-			schedule_work(&adapter->ptp_tx_work);
-		}
-	}
+	if (icr & E1000_ICR_TS)
+		igb_tsync_interrupt(adapter);
 #endif /* HAVE_PTP_1588_CLOCK */
 
 	napi_schedule(&q_vector->napi);

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -6053,7 +6053,8 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	struct ptp_clock_event event;
-	u32 ack = 0, tsicr = rd32(E1000_TSICR);
+	struct timespec ts;
+	u32 ack = 0, tsauxc, sec, nsec, tsicr = rd32(E1000_TSICR);
 
 	if (tsicr & TSINTR_SYS_WRAP) {
 		event.type = PTP_CLOCK_PPS;
@@ -6068,6 +6069,54 @@ static void igb_tsync_interrupt(struct igb_adapter *adapter)
 		/* retrieve hardware timestamp */
 		schedule_work(&adapter->ptp_tx_work);
 		ack |= E1000_TSICR_TXTS;
+	}
+
+	if (tsicr & TSINTR_TT0) {
+		spin_lock(&adapter->tmreg_lock);
+		ts = timespec_add(adapter->perout[0].start,
+				  adapter->perout[0].period);
+		wr32(E1000_TRGTTIML0, ts.tv_nsec);
+		wr32(E1000_TRGTTIMH0, ts.tv_sec);
+		tsauxc = rd32(E1000_TSAUXC);
+		tsauxc |= TSAUXC_EN_TT0;
+		wr32(E1000_TSAUXC, tsauxc);
+		adapter->perout[0].start = ts;
+		spin_unlock(&adapter->tmreg_lock);
+		ack |= TSINTR_TT0;
+	}
+
+	if (tsicr & TSINTR_TT1) {
+		spin_lock(&adapter->tmreg_lock);
+		ts = timespec_add(adapter->perout[1].start,
+				  adapter->perout[1].period);
+		wr32(E1000_TRGTTIML1, ts.tv_nsec);
+		wr32(E1000_TRGTTIMH1, ts.tv_sec);
+		tsauxc = rd32(E1000_TSAUXC);
+		tsauxc |= TSAUXC_EN_TT1;
+		wr32(E1000_TSAUXC, tsauxc);
+		adapter->perout[1].start = ts;
+		spin_unlock(&adapter->tmreg_lock);
+		ack |= TSINTR_TT1;
+	}
+
+	if (tsicr & TSINTR_AUTT0) {
+		nsec = rd32(E1000_AUXSTMPL0);
+		sec  = rd32(E1000_AUXSTMPH0);
+		event.type = PTP_CLOCK_EXTTS;
+		event.index = 0;
+		event.timestamp = sec * 1000000000ULL + nsec;
+		ptp_clock_event(adapter->ptp_clock, &event);
+		ack |= TSINTR_AUTT0;
+	}
+
+	if (tsicr & TSINTR_AUTT1) {
+		nsec = rd32(E1000_AUXSTMPL1);
+		sec  = rd32(E1000_AUXSTMPH1);
+		event.type = PTP_CLOCK_EXTTS;
+		event.index = 1;
+		event.timestamp = sec * 1000000000ULL + nsec;
+		ptp_clock_event(adapter->ptp_clock, &event);
+		ack |= TSINTR_AUTT1;
 	}
 
 	/* acknowledge the interrupts */

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -2686,7 +2686,6 @@ static int igb_probe(struct pci_dev *pdev,
 	adapter->msg_enable = (1 << debug) - 1;
 
 	/* AVB specific */
-	adapter->userpages = NULL;
 	adapter->uring_tx_init = 0;
 	adapter->uring_rx_init = 0;
 	mutex_init(&adapter->lock);
@@ -10137,6 +10136,7 @@ static struct igb_adapter *igb_lookup(char *id)
 
 static int igb_bind(struct file *file, void __user *argp)
 {
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_bind_cmd req;
 	int err = 0;
@@ -10146,13 +10146,18 @@ static int igb_bind(struct file *file, void __user *argp)
 
 	printk("bind to iface %s\n", req.iface);
 
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
 	adapter = igb_lookup(req.iface);
 	if (adapter == NULL) {
 		printk("lookup failed to iface %s\n", req.iface);
 		return -ENOENT;
 	}
 
-	file->private_data = adapter;
+	igb_priv->adapter = adapter;
 
 	req.mmap_size = 0;
 	req.mmap_size = pci_resource_len(adapter->pdev, 0);
@@ -10166,30 +10171,41 @@ static int igb_bind(struct file *file, void __user *argp)
 	return 0;
 
 failed:
-	file->private_data = NULL;
+	igb_priv->adapter = NULL;
 	return err;
 }
 
 static int igb_unbind(struct file *file)
 {
 	struct igb_adapter *adapter;
+	struct igb_private_data *igb_priv = file->private_data;
 
-	adapter = file->private_data;
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
 
+	adapter = igb_priv->adapter;
 	if (adapter == NULL)
 		return -EBADFD;
 
-	file->private_data = NULL;
+	igb_priv->adapter = NULL;
 	return 0;
 }
 
 static long igb_getspeed(struct file *file, void __user *arg)
 {
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_link_cmd req;
 	u32	link;
 
-	adapter = file->private_data;
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL) {
 		printk("map to unbound device!\n");
 		return -ENOENT;
@@ -10213,16 +10229,118 @@ static long igb_getspeed(struct file *file, void __user *arg)
 	return 0;
 }
 
-static long igb_mapbuf(struct file *file, void __user *arg, int ring)
+static long igb_mapbuf_user(struct file *file, void __user *arg, int ring)
 {
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_buf_cmd req;
 	int err = 0;
+	struct page *page;
+	dma_addr_t page_dma;
+	struct igb_user_page *userpage;
+
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
+	if (adapter == NULL) {
+		printk("map to unbound device!\n");
+		return -ENOENT;
+	}
 
 	if (copy_from_user(&req, arg, sizeof(req)))
 		return -EFAULT;
 
-	adapter = file->private_data;
+	userpage = vzalloc(sizeof(struct igb_user_page));
+	if (unlikely(!userpage)) {
+		err = -ENOMEM;
+		goto failed;
+	}
+
+	mutex_lock(&adapter->lock);
+	if (igb_priv->userpages == NULL) {
+		igb_priv->userpages = userpage;
+	} else {
+		userpage->next = igb_priv->userpages;
+		igb_priv->userpages->prev = userpage;
+		igb_priv->userpages = userpage;
+	}
+
+#if defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL)
+#if defined(CONFIG_ZONE_DMA32)
+	page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA32);
+#else /* defined(CONFIG_ZONE_DMA32) */
+	page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA);
+#endif /* defined(CONFIG_ZONE_DMA32) */
+#else /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
+	page = alloc_page(GFP_ATOMIC | __GFP_COLD);
+#endif /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
+	if (unlikely(!page)) {
+		err = -ENOMEM;
+		goto page_failed;
+	}
+
+	page_dma = dma_map_page(pci_dev_to_dev(adapter->pdev), page,
+			0, PAGE_SIZE, DMA_FROM_DEVICE);
+
+	if (dma_mapping_error(pci_dev_to_dev(adapter->pdev), page_dma)) {
+		err = -ENOMEM;
+		goto map_failed;
+	}
+
+	igb_priv->userpages->page = page;
+	igb_priv->userpages->page_dma = page_dma;
+
+	req.physaddr = page_dma;
+	req.mmap_size = PAGE_SIZE;
+	mutex_unlock(&adapter->lock);
+
+	if (copy_to_user(arg, &req, sizeof(req))) {
+		printk("copyout to user failed\n");
+		err = -EFAULT;
+		mutex_lock(&adapter->lock);
+		goto copy_failed;
+	}
+
+	return 0;
+
+copy_failed:
+	dma_unmap_page(pci_dev_to_dev(adapter->pdev),
+			userpage->page_dma, PAGE_SIZE,
+			DMA_FROM_DEVICE);
+map_failed:
+	put_page(userpage->page);
+page_failed:
+	if (userpage->prev)
+		userpage->prev->next = userpage->next;
+	if (userpage->next)
+		userpage->next->prev = userpage->prev;
+	if (userpage == igb_priv->userpages)
+		igb_priv->userpages = userpage->next;
+	vfree(userpage);
+	mutex_unlock(&adapter->lock);
+failed:
+	return err;
+}
+
+static long igb_mapbuf(struct file *file, void __user *arg, int ring)
+{
+	struct igb_private_data *igb_priv = file->private_data;
+	struct igb_adapter *adapter;
+	struct igb_buf_cmd req;
+	int err = 0;
+
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	if (copy_from_user(&req, arg, sizeof(req)))
+		return -EFAULT;
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL) {
 		printk("map to unbound device!\n");
 		return -ENOENT;
@@ -10235,15 +10353,19 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 			return -EINVAL;
 		}
 
+		mutex_lock(&adapter->lock);
 		if (adapter->uring_tx_init & (1 << req.queue)) {
+			mutex_unlock(&adapter->lock);
 			printk("mapring:queue in use (%d)\n", req.queue);
 			return -EBUSY;
 		}
 
 		adapter->uring_tx_init |= (1 << req.queue);
+		igb_priv->uring_tx_init |= (1 << req.queue);
 
 		req.physaddr = adapter->tx_ring[req.queue]->dma;
 		req.mmap_size = adapter->tx_ring[req.queue]->size;
+		mutex_unlock(&adapter->lock);
 	} else if (ring == IGB_MAP_RX_RING) {
 		if (req.queue >= 3) {
 			printk("mapring:invalid queue specified(%d)\n",
@@ -10251,66 +10373,22 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 			return -EINVAL;
 		}
 
+		mutex_lock(&adapter->lock);
 		if (adapter->uring_rx_init & (1 << req.queue)) {
+			mutex_unlock(&adapter->lock);
 			printk("mapring:queue in use (%d)\n", req.queue);
 			return -EBUSY;
 		}
 
 		adapter->uring_rx_init |= (1 << req.queue);
+		igb_priv->uring_rx_init |= (1 << req.queue);
 
 		req.physaddr = adapter->rx_ring[req.queue]->dma;
 		req.mmap_size = adapter->rx_ring[req.queue]->size;
-	} else {
-		struct page *page;
-		dma_addr_t page_dma;
-		struct igb_user_page *userpage;
-
-		userpage = vzalloc(sizeof(struct igb_user_page));
-		if (unlikely(!userpage)) {
-			err = -ENOMEM;
-			goto failed;
-		}
-
-		mutex_lock(&adapter->lock);
-		if (adapter->userpages == NULL) {
-			adapter->userpages = userpage;
-		} else {
-			userpage->next = adapter->userpages;
-			adapter->userpages->prev = userpage;
-			adapter->userpages = userpage;
-		}
-
-#if defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL)
-#if defined(CONFIG_ZONE_DMA32)
-		page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA32);
-#else /* defined(CONFIG_ZONE_DMA32) */
-		page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA);
-#endif /* defined(CONFIG_ZONE_DMA32) */
-#else /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
-		page = alloc_page(GFP_ATOMIC | __GFP_COLD);
-#endif /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
-		if (unlikely(!page)) {
-			err = -ENOMEM;
-			mutex_unlock(&adapter->lock);
-			goto failed;
-		}
-
-		page_dma = dma_map_page(pci_dev_to_dev(adapter->pdev), page,
-					0, PAGE_SIZE, DMA_FROM_DEVICE);
-
-		if (dma_mapping_error(pci_dev_to_dev(adapter->pdev), page_dma)) {
-			put_page(page);
-			err = -ENOMEM;
-			mutex_unlock(&adapter->lock);
-			goto failed;;
-		}
-
-		adapter->userpages->page = page;
-		adapter->userpages->page_dma = page_dma;
-
-		req.physaddr = page_dma;
-		req.mmap_size = PAGE_SIZE;
 		mutex_unlock(&adapter->lock);
+	} else {
+		printk("mapring: invalid ioctl %d\n", _IOC_NR(ring));
+		return -EINVAL;
 	}
 
 	if (copy_to_user(arg, &req, sizeof(req))) {
@@ -10328,13 +10406,19 @@ failed:
 static long igb_unmapbuf(struct file *file, void __user *arg, int ring)
 {
 	int err = 0;
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_buf_cmd req;
+
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
 
 	if (copy_from_user(&req, arg, sizeof(req)))
 		return -EFAULT;
 
-	adapter = file->private_data;
+	adapter = igb_priv->adapter;
 	if (adapter == NULL) {
 		printk("map to unbound device!\n");
 		return -ENOENT;
@@ -10345,25 +10429,43 @@ static long igb_unmapbuf(struct file *file, void __user *arg, int ring)
 		if (req.queue >= 3)
 			return -EINVAL;
 
-		if (0 == (adapter->uring_tx_init & (1 << req.queue)))
+		mutex_lock(&adapter->lock);
+		if (0 == (igb_priv->uring_tx_init & (1 << req.queue))) {
+			mutex_unlock(&adapter->lock);
 			return -EINVAL;
+		} else {
+			if (0 == (adapter->uring_tx_init & (1 << req.queue))) {
+				printk("Warning: invalid tx ring buffer state!\n");
+			}
+		}
 
 		adapter->uring_tx_init &= ~(1 << req.queue);
+		igb_priv->uring_tx_init &= ~(1 << req.queue);
+		mutex_unlock(&adapter->lock);
 	} else if (ring == IGB_UNMAP_RX_RING) {
 		/* its easy to figure out what to free on the rings ... */
 		if (req.queue >= 3)
 			return -EINVAL;
 
-		if (0 == (adapter->uring_rx_init & (1 << req.queue)))
+		mutex_lock(&adapter->lock);
+		if (0 == (igb_priv->uring_rx_init & (1 << req.queue))) {
+			mutex_unlock(&adapter->lock);
 			return -EINVAL;
+		} else {
+			if (0 == (adapter->uring_rx_init & (1 << req.queue))) {
+				printk("Warning: invalid rx ring buffer state!\n");
+			}
+		}
 
 		adapter->uring_rx_init &= ~(1 << req.queue);
+		igb_priv->uring_rx_init &= ~(1 << req.queue);
+		mutex_unlock(&adapter->lock);
 	} else {
 		/* have to find the corresponding page to free */
-		struct igb_user_page *userpage; 
+		struct igb_user_page *userpage;
 
 		mutex_lock(&adapter->lock);
-		userpage = adapter->userpages;
+		userpage = igb_priv->userpages;
 
 		while (userpage != NULL) {
 			if (req.physaddr == userpage->page_dma)
@@ -10390,8 +10492,8 @@ static long igb_unmapbuf(struct file *file, void __user *arg, int ring)
 		if (userpage->next)
 			userpage->next->prev = userpage->prev;
 
-		if (userpage == adapter->userpages)
-			adapter->userpages = userpage->next;
+		if (userpage == igb_priv->userpages)
+			igb_priv->userpages = userpage->next;
 
 		vfree(userpage);
 		mutex_unlock(&adapter->lock);
@@ -10414,8 +10516,10 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 		break;
 	case IGB_MAP_TX_RING:
 	case IGB_MAP_RX_RING:
-	case IGB_MAPBUF:
 		err = igb_mapbuf(file, argp, cmd);
+		break;
+	case IGB_MAPBUF:
+		err = igb_mapbuf_user(file, argp, cmd);
 		break;
 	case IGB_UNMAP_TX_RING:
 	case IGB_UNMAP_RX_RING:
@@ -10435,37 +10539,67 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 
 static int igb_open_file(struct inode *inode, struct file *file)
 {
-	file->private_data = NULL;
-	return 0;
+       struct igb_private_data *igb_priv = NULL;
+       int ret = 0;
+
+       igb_priv = kzalloc(sizeof(struct igb_private_data *), GFP_KERNEL);
+       if (igb_priv == NULL) {
+               ret = -ENOMEM;
+               goto out;
+       }
+       igb_priv->uring_tx_init = 0;
+       igb_priv->uring_rx_init = 0;
+       igb_priv->userpages = NULL;
+       igb_priv->adapter = NULL;
+out:
+       file->private_data = igb_priv;
+       return ret;
 }
 
 static int igb_close_file(struct inode *inode, struct file *file)
 {
-	struct igb_adapter *adapter = file->private_data;
-	int err;
+	struct igb_private_data *igb_priv = file->private_data;
+	struct igb_adapter *adapter = NULL;
+	int err = 0;
 	int i;
 	struct igb_user_page *userpage;
 
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL)
-		return 0;
-
-	/* free up any rings and user-mapped pages */
-	for (i = 0; i < 3; i++) {
-		if (adapter->uring_tx_init & (1 << i)) {
-			igb_free_tx_resources(adapter->tx_ring[i]);
-			adapter->uring_tx_init &= ~(1 << i);
-		}
-	}
-
-	for (i = 0; i < 3; i++) {
-		if (adapter->uring_rx_init & (1 << i)) {
-			igb_free_rx_resources(adapter->rx_ring[i]);
-			adapter->uring_rx_init &= ~(1 << i);
-		}
-	}
+		goto out;
 
 	mutex_lock(&adapter->lock);
-	userpage = adapter->userpages;
+	/* free up any rings and user-mapped pages */
+	for (i = 0; i < 3; i++) {
+		if (igb_priv->uring_tx_init & (1 << i)) {
+			if (adapter->uring_tx_init & (1 << i)) {
+				igb_free_tx_resources(adapter->tx_ring[i]);
+			} else {
+				printk("Warning: invalid tx ring buffer state!\n");
+			}
+			adapter->uring_tx_init &= ~(1 << i);
+			igb_priv->uring_tx_init &= ~(1 << i);
+		}
+	}
+
+	for (i = 0; i < 3; i++) {
+		if (igb_priv->uring_rx_init & (1 << i)) {
+			if (adapter->uring_rx_init & (1 << i)) {
+				igb_free_rx_resources(adapter->rx_ring[i]);
+			} else {
+				printk("Warning: invalid rx ring buffer state!\n");
+			}
+			adapter->uring_rx_init &= ~(1 << i);
+			igb_priv->uring_rx_init &= ~(1 << i);
+		}
+	}
+
+	userpage = igb_priv->userpages;
 
 	while (userpage != NULL) {
 		dma_unmap_page(pci_dev_to_dev(adapter->pdev),
@@ -10482,15 +10616,18 @@ static int igb_close_file(struct inode *inode, struct file *file)
 		if (userpage->next)
 			userpage->next->prev = userpage->prev;
 
-		if (userpage == adapter->userpages)
-			adapter->userpages = userpage->next;
+		if (userpage == igb_priv->userpages)
+			igb_priv->userpages = userpage->next;
 
 		vfree(userpage);
-		userpage = adapter->userpages;
+		userpage = igb_priv->userpages;
 	}
 	mutex_unlock(&adapter->lock);
 
 	err = igb_unbind(file);
+out:
+	file->private_data = NULL;
+	kfree(igb_priv);
 	return err;
 }
 
@@ -10509,11 +10646,18 @@ static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata)
 
 static int igb_mmap(struct file *file, struct vm_area_struct *vma)
 {
-	struct igb_adapter *adapter = file->private_data;
+	struct igb_private_data *igb_priv = file->private_data;
+	struct igb_adapter *adapter = NULL;
 	unsigned long size  = vma->vm_end - vma->vm_start;
 	dma_addr_t pgoff = vma->vm_pgoff;
 	dma_addr_t physaddr;
 
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL)
 		return -ENODEV;
 

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -6052,14 +6052,26 @@ void igb_update_stats(struct igb_adapter *adapter)
 static void igb_tsync_interrupt(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
-	u32 tsicr = rd32(E1000_TSICR);
+	struct ptp_clock_event event;
+	u32 ack = 0, tsicr = rd32(E1000_TSICR);
+
+	if (tsicr & TSINTR_SYS_WRAP) {
+		event.type = PTP_CLOCK_PPS;
+		if (adapter->ptp_caps.pps)
+			ptp_clock_event(adapter->ptp_clock, &event);
+		else
+			dev_err(&adapter->pdev->dev, "unexpected SYS WRAP");
+		ack |= TSINTR_SYS_WRAP;
+	}
 
 	if (tsicr & E1000_TSICR_TXTS) {
-		/* acknowledge the interrupt */
-		wr32(E1000_TSICR, E1000_TSICR_TXTS);
 		/* retrieve hardware timestamp */
 		schedule_work(&adapter->ptp_tx_work);
+		ack |= E1000_TSICR_TXTS;
 	}
+
+	/* acknowledge the interrupts */
+	wr32(E1000_TSICR, ack);
 }
 
 static irqreturn_t igb_msix_other(int irq, void *data)

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -634,7 +634,8 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 		ts.tv_nsec = rq->perout.period.nsec;
 		ns = timespec64_to_ns(&ts);
 		ns = ns >> 1;
-		if (on && ns <= 70000000LL) {
+		if (on && ((ns <= 70000000LL) || (ns == 125000000LL) ||
+			   (ns == 250000000LL) || (ns == 500000000LL))) {
 			if (ns < 8LL)
 				return -EINVAL;
 			use_freq = 1;

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -471,16 +471,204 @@ static int igb_ptp_settime_i210(struct ptp_clock_info *ptp,
 }
 
 #endif
+static void igb_pin_direction(int pin, int input, u32 *ctrl, u32 *ctrl_ext)
+{
+	u32 *ptr = pin < 2 ? ctrl : ctrl_ext;
+	u32 mask[IGB_N_SDP] = {
+		E1000_CTRL_SDP0_DIR,
+		E1000_CTRL_SDP1_DIR,
+		E1000_CTRL_EXT_SDP2_DIR,
+		E1000_CTRL_EXT_SDP3_DIR,
+	};
+
+	if (input)
+		*ptr &= ~mask[pin];
+	else
+		*ptr |= mask[pin];
+}
+
+static void igb_pin_extts(struct igb_adapter *igb, int chan, int pin)
+{
+	struct e1000_hw *hw = &igb->hw;
+	u32 aux0_sel_sdp[IGB_N_SDP] = {
+		AUX0_SEL_SDP0, AUX0_SEL_SDP1, AUX0_SEL_SDP2, AUX0_SEL_SDP3,
+	};
+	u32 aux1_sel_sdp[IGB_N_SDP] = {
+		AUX1_SEL_SDP0, AUX1_SEL_SDP1, AUX1_SEL_SDP2, AUX1_SEL_SDP3,
+	};
+	u32 ts_sdp_en[IGB_N_SDP] = {
+		TS_SDP0_EN, TS_SDP1_EN, TS_SDP2_EN, TS_SDP3_EN,
+	};
+	u32 ctrl, ctrl_ext, tssdp = 0;
+
+	ctrl = rd32(E1000_CTRL);
+	ctrl_ext = rd32(E1000_CTRL_EXT);
+	tssdp = rd32(E1000_TSSDP);
+
+	igb_pin_direction(pin, 1, &ctrl, &ctrl_ext);
+
+	/* Make sure this pin is not enabled as an output. */
+	tssdp &= ~ts_sdp_en[pin];
+
+	if (chan == 1) {
+		tssdp &= ~AUX1_SEL_SDP3;
+		tssdp |= aux1_sel_sdp[pin] | AUX1_TS_SDP_EN;
+	} else {
+		tssdp &= ~AUX0_SEL_SDP3;
+		tssdp |= aux0_sel_sdp[pin] | AUX0_TS_SDP_EN;
+	}
+
+	wr32(E1000_TSSDP, tssdp);
+	wr32(E1000_CTRL, ctrl);
+	wr32(E1000_CTRL_EXT, ctrl_ext);
+}
+
+static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin)
+{
+	struct e1000_hw *hw = &igb->hw;
+	u32 aux0_sel_sdp[IGB_N_SDP] = {
+		AUX0_SEL_SDP0, AUX0_SEL_SDP1, AUX0_SEL_SDP2, AUX0_SEL_SDP3,
+	};
+	u32 aux1_sel_sdp[IGB_N_SDP] = {
+		AUX1_SEL_SDP0, AUX1_SEL_SDP1, AUX1_SEL_SDP2, AUX1_SEL_SDP3,
+	};
+	u32 ts_sdp_en[IGB_N_SDP] = {
+		TS_SDP0_EN, TS_SDP1_EN, TS_SDP2_EN, TS_SDP3_EN,
+	};
+	u32 ts_sdp_sel_tt0[IGB_N_SDP] = {
+		TS_SDP0_SEL_TT0, TS_SDP1_SEL_TT0,
+		TS_SDP2_SEL_TT0, TS_SDP3_SEL_TT0,
+	};
+	u32 ts_sdp_sel_tt1[IGB_N_SDP] = {
+		TS_SDP0_SEL_TT1, TS_SDP1_SEL_TT1,
+		TS_SDP2_SEL_TT1, TS_SDP3_SEL_TT1,
+	};
+	u32 ts_sdp_sel_clr[IGB_N_SDP] = {
+		TS_SDP0_SEL_FC1, TS_SDP1_SEL_FC1,
+		TS_SDP2_SEL_FC1, TS_SDP3_SEL_FC1,
+	};
+	u32 ctrl, ctrl_ext, tssdp = 0;
+
+	ctrl = rd32(E1000_CTRL);
+	ctrl_ext = rd32(E1000_CTRL_EXT);
+	tssdp = rd32(E1000_TSSDP);
+
+	igb_pin_direction(pin, 0, &ctrl, &ctrl_ext);
+
+	/* Make sure this pin is not enabled as an input. */
+	if ((tssdp & AUX0_SEL_SDP3) == aux0_sel_sdp[pin])
+		tssdp &= ~AUX0_TS_SDP_EN;
+
+	if ((tssdp & AUX1_SEL_SDP3) == aux1_sel_sdp[pin])
+		tssdp &= ~AUX1_TS_SDP_EN;
+
+	tssdp &= ~ts_sdp_sel_clr[pin];
+	if (chan == 1)
+		tssdp |= ts_sdp_sel_tt1[pin];
+	else
+		tssdp |= ts_sdp_sel_tt0[pin];
+
+	tssdp |= ts_sdp_en[pin];
+
+	wr32(E1000_TSSDP, tssdp);
+	wr32(E1000_CTRL, ctrl);
+	wr32(E1000_CTRL_EXT, ctrl_ext);
+}
+
 static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 				       struct ptp_clock_request *rq, int on)
 {
 	struct igb_adapter *igb =
 		container_of(ptp, struct igb_adapter, ptp_caps);
 	struct e1000_hw *hw = &igb->hw;
+	u32 tsauxc, tsim, tsauxc_mask, tsim_mask, trgttiml, trgttimh;
 	unsigned long flags;
-	u32 tsim;
+	struct timespec ts;
+	int pin;
+	s64 ns;
 
 	switch (rq->type) {
+	case PTP_CLK_REQ_EXTTS:
+		if (on) {
+			pin = ptp_find_pin(igb->ptp_clock, PTP_PF_EXTTS,
+					   rq->extts.index);
+			if (pin < 0)
+				return -EBUSY;
+		}
+		if (rq->extts.index == 1) {
+			tsauxc_mask = TSAUXC_EN_TS1;
+			tsim_mask = TSINTR_AUTT1;
+		} else {
+			tsauxc_mask = TSAUXC_EN_TS0;
+			tsim_mask = TSINTR_AUTT0;
+		}
+		spin_lock_irqsave(&igb->tmreg_lock, flags);
+		tsauxc = rd32(E1000_TSAUXC);
+		tsim = rd32(E1000_TSIM);
+		if (on) {
+			igb_pin_extts(igb, rq->extts.index, pin);
+			tsauxc |= tsauxc_mask;
+			tsim |= tsim_mask;
+		} else {
+			tsauxc &= ~tsauxc_mask;
+			tsim &= ~tsim_mask;
+		}
+		wr32(E1000_TSAUXC, tsauxc);
+		wr32(E1000_TSIM, tsim);
+		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
+		return 0;
+
+	case PTP_CLK_REQ_PEROUT:
+		if (on) {
+			pin = ptp_find_pin(igb->ptp_clock, PTP_PF_PEROUT,
+					   rq->perout.index);
+			if (pin < 0)
+				return -EBUSY;
+		}
+		ts.tv_sec = rq->perout.period.sec;
+		ts.tv_nsec = rq->perout.period.nsec;
+		ns = timespec_to_ns(&ts);
+		ns = ns >> 1;
+		if (on && ns < 500000LL) {
+			/* 2k interrupts per second is an awful lot. */
+			return -EINVAL;
+		}
+		ts = ns_to_timespec(ns);
+		if (rq->perout.index == 1) {
+			tsauxc_mask = TSAUXC_EN_TT1;
+			tsim_mask = TSINTR_TT1;
+			trgttiml = E1000_TRGTTIML1;
+			trgttimh = E1000_TRGTTIMH1;
+		} else {
+			tsauxc_mask = TSAUXC_EN_TT0;
+			tsim_mask = TSINTR_TT0;
+			trgttiml = E1000_TRGTTIML0;
+			trgttimh = E1000_TRGTTIMH0;
+		}
+		spin_lock_irqsave(&igb->tmreg_lock, flags);
+		tsauxc = rd32(E1000_TSAUXC);
+		tsim = rd32(E1000_TSIM);
+		if (on) {
+			int i = rq->perout.index;
+
+			igb_pin_perout(igb, i, pin);
+			igb->perout[i].start.tv_sec = rq->perout.start.sec;
+			igb->perout[i].start.tv_nsec = rq->perout.start.nsec;
+			igb->perout[i].period.tv_sec = ts.tv_sec;
+			igb->perout[i].period.tv_nsec = ts.tv_nsec;
+			wr32(trgttiml, rq->perout.start.sec);
+			wr32(trgttimh, rq->perout.start.nsec);
+			tsauxc |= tsauxc_mask;
+			tsim |= tsim_mask;
+		} else {
+			tsauxc &= ~tsauxc_mask;
+			tsim &= ~tsim_mask;
+		}
+		wr32(E1000_TSAUXC, tsauxc);
+		wr32(E1000_TSIM, tsim);
+		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
+		return 0;
+
 	case PTP_CLK_REQ_PPS:
 		spin_lock_irqsave(&igb->tmreg_lock, flags);
 		tsim = rd32(E1000_TSIM);
@@ -491,9 +679,6 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 		wr32(E1000_TSIM, tsim);
 		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
 		return 0;
-
-	default:
-		break;
 	}
 
 	return -EOPNOTSUPP;
@@ -503,6 +688,20 @@ static int igb_ptp_feature_enable(struct ptp_clock_info *ptp,
 				  struct ptp_clock_request *rq, int on)
 {
 	return -EOPNOTSUPP;
+}
+
+static int igb_ptp_verify_pin(struct ptp_clock_info *ptp, unsigned int pin,
+			      enum ptp_pin_function func, unsigned int chan)
+{
+	switch (func) {
+	case PTP_PF_NONE:
+	case PTP_PF_EXTTS:
+	case PTP_PF_PEROUT:
+		break;
+	case PTP_PF_PHYSYNC:
+		return -1;
+	}
+	return 0;
 }
 
 /**
@@ -901,6 +1100,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	struct net_device *netdev = adapter->netdev;
+	int i;
 
 	switch (hw->mac.type) {
 	case e1000_82576:
@@ -954,11 +1154,21 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		break;
 	case e1000_i210:
 	case e1000_i211:
+		for (i = 0; i < IGB_N_SDP; i++) {
+			struct ptp_pin_desc *ppd = &adapter->sdp_config[i];
+
+			snprintf(ppd->name, sizeof(ppd->name), "SDP%d", i);
+			ppd->index = i;
+			ppd->func = PTP_PF_NONE;
+		}
 		snprintf(adapter->ptp_caps.name, 16, "%pm", netdev->dev_addr);
 		adapter->ptp_caps.owner = THIS_MODULE;
 		adapter->ptp_caps.max_adj = 62499999;
-		adapter->ptp_caps.n_ext_ts = 0;
+		adapter->ptp_caps.n_ext_ts = IGB_N_EXTTS;
+		adapter->ptp_caps.n_per_out = IGB_N_PEROUT;
+		adapter->ptp_caps.n_pins = IGB_N_SDP;
 		adapter->ptp_caps.pps = 1;
+		adapter->ptp_caps.pin_config = adapter->sdp_config;
 		adapter->ptp_caps.adjfreq = igb_ptp_adjfreq_82580;
 		adapter->ptp_caps.adjtime = igb_ptp_adjtime_i210;
 #ifdef HAVE_PTP_CLOCK_INFO_GETTIME64
@@ -969,6 +1179,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		adapter->ptp_caps.settime = igb_ptp_settime_i210;
 #endif
 		adapter->ptp_caps.enable = igb_ptp_feature_enable_i210;
+		adapter->ptp_caps.verify = igb_ptp_verify_pin;
 		/* Enable the timer functions by clearing bit 31. */
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
 		break;
@@ -1088,6 +1299,7 @@ void igb_ptp_reset(struct igb_adapter *adapter)
 	case e1000_i210:
 	case e1000_i211:
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
+		wr32(E1000_TSSDP, 0x0);
 		E1000_WRITE_REG(hw, E1000_TSIM, TSYNC_INTERRUPTS);
 		E1000_WRITE_REG(hw, E1000_IMS, E1000_IMS_TS);
 		break;

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -166,7 +166,7 @@ static void igb_ptp_write_i210(struct igb_adapter *adapter,
 	 * sub-nanosecond resolution.
 	 */
 	E1000_WRITE_REG(hw, E1000_SYSTIML, ts->tv_nsec);
-	E1000_WRITE_REG(hw, E1000_SYSTIMH, ts->tv_sec);
+	E1000_WRITE_REG(hw, E1000_SYSTIMH, (u32)ts->tv_sec);
 }
 
 /**
@@ -588,7 +588,7 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 	struct e1000_hw *hw = &igb->hw;
 	u32 tsauxc, tsim, tsauxc_mask, tsim_mask, trgttiml, trgttimh, freqout;
 	unsigned long flags;
-	struct timespec ts;
+	struct timespec64 ts;
 	int use_freq = 0, pin = -1;
 	s64 ns;
 
@@ -632,14 +632,14 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 		}
 		ts.tv_sec = rq->perout.period.sec;
 		ts.tv_nsec = rq->perout.period.nsec;
-		ns = timespec_to_ns(&ts);
+		ns = timespec64_to_ns(&ts);
 		ns = ns >> 1;
 		if (on && ns <= 70000000LL) {
 			if (ns < 8LL)
 				return -EINVAL;
 			use_freq = 1;
 		}
-		ts = ns_to_timespec(ns);
+		ts = ns_to_timespec64(ns);
 		if (rq->perout.index == 1) {
 			if (use_freq) {
 				tsauxc_mask = TSAUXC_EN_CLK1 | TSAUXC_ST1;

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -647,8 +647,8 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 			igb->perout[i].start.tv_nsec = rq->perout.start.nsec;
 			igb->perout[i].period.tv_sec = ts.tv_sec;
 			igb->perout[i].period.tv_nsec = ts.tv_nsec;
-			wr32(trgttiml, rq->perout.start.sec);
-			wr32(trgttimh, rq->perout.start.nsec);
+			wr32(trgttimh, rq->perout.start.sec);
+			wr32(trgttiml, rq->perout.start.nsec);
 			tsauxc |= tsauxc_mask;
 			tsim |= tsim_mask;
 		} else {

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -1038,12 +1038,15 @@ void igb_ptp_stop(struct igb_adapter *adapter)
 void igb_ptp_reset(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
+	unsigned long flags;
 
 	if (!(adapter->flags & IGB_FLAG_PTP))
 		return;
 
 	/* reset the tstamp_config */
 	igb_ptp_set_timestamp_mode(adapter, &adapter->tstamp_config);
+
+	spin_lock_irqsave(&adapter->tmreg_lock, flags);
 
 	switch (adapter->hw.mac.type) {
 	case e1000_82576:
@@ -1056,24 +1059,25 @@ void igb_ptp_reset(struct igb_adapter *adapter)
 	case e1000_i354:
 	case e1000_i210:
 	case e1000_i211:
-		/* Enable the timer functions and interrupts. */
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
 		E1000_WRITE_REG(hw, E1000_TSIM, TSYNC_INTERRUPTS);
 		E1000_WRITE_REG(hw, E1000_IMS, E1000_IMS_TS);
 		break;
 	default:
 		/* No work to do. */
-		return;
+		goto out;
 	}
 
 	/* Re-initialize the timer. */
 	if ((hw->mac.type == e1000_i210) || (hw->mac.type == e1000_i211)) {
 		struct timespec64 ts64 = ktime_to_timespec64(ktime_get_real());
 
-		igb_ptp_settime64_i210(&adapter->ptp_caps, &ts64);
+		igb_ptp_write_i210(adapter, &ts64);
 	} else {
 		timecounter_init(&adapter->tc, &adapter->cc,
 				 ktime_to_ns(ktime_get_real()));
 	}
+out:
+	spin_unlock_irqrestore(&adapter->tmreg_lock, flags);
 }
 #endif /* HAVE_PTP_1588_CLOCK */

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -471,8 +471,8 @@ static int igb_ptp_settime_i210(struct ptp_clock_info *ptp,
 }
 
 #endif
-static int igb_ptp_enable(struct ptp_clock_info *ptp,
-			  struct ptp_clock_request *rq, int on)
+static int igb_ptp_feature_enable(struct ptp_clock_info *ptp,
+				  struct ptp_clock_request *rq, int on)
 {
 	return -EOPNOTSUPP;
 }
@@ -890,7 +890,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		adapter->ptp_caps.gettime = igb_ptp_gettime_82576;
 		adapter->ptp_caps.settime = igb_ptp_settime_82576;
 #endif
-		adapter->ptp_caps.enable = igb_ptp_enable;
+		adapter->ptp_caps.enable = igb_ptp_feature_enable;
 		adapter->cc.read = igb_ptp_read_82576;
 		adapter->cc.mask = CLOCKSOURCE_MASK(64);
 		adapter->cc.mult = 1;
@@ -916,7 +916,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		adapter->ptp_caps.gettime = igb_ptp_gettime_82576;
 		adapter->ptp_caps.settime = igb_ptp_settime_82576;
 #endif
-		adapter->ptp_caps.enable = igb_ptp_enable;
+		adapter->ptp_caps.enable = igb_ptp_feature_enable;
 		adapter->cc.read = igb_ptp_read_82580;
 		adapter->cc.mask = CLOCKSOURCE_MASK(IGB_NBITS_82580);
 		adapter->cc.mult = 1;
@@ -940,7 +940,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		adapter->ptp_caps.gettime = igb_ptp_gettime_i210;
 		adapter->ptp_caps.settime = igb_ptp_settime_i210;
 #endif
-		adapter->ptp_caps.enable = igb_ptp_enable;
+		adapter->ptp_caps.enable = igb_ptp_feature_enable;
 		/* Enable the timer functions by clearing bit 31. */
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
 		break;

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -972,7 +972,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 
 	/* Initialize the time sync interrupts for devices that support it. */
 	if (hw->mac.type >= e1000_82580) {
-		E1000_WRITE_REG(hw, E1000_TSIM, E1000_TSIM_TXTS);
+		E1000_WRITE_REG(hw, E1000_TSIM, TSYNC_INTERRUPTS);
 		E1000_WRITE_REG(hw, E1000_IMS, E1000_IMS_TS);
 	}
 
@@ -1058,7 +1058,7 @@ void igb_ptp_reset(struct igb_adapter *adapter)
 	case e1000_i211:
 		/* Enable the timer functions and interrupts. */
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
-		E1000_WRITE_REG(hw, E1000_TSIM, E1000_TSIM_TXTS);
+		E1000_WRITE_REG(hw, E1000_TSIM, TSYNC_INTERRUPTS);
 		E1000_WRITE_REG(hw, E1000_IMS, E1000_IMS_TS);
 		break;
 	default:

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -563,17 +563,10 @@ static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin, int freq)
 		tssdp &= ~AUX1_TS_SDP_EN;
 
 	tssdp &= ~ts_sdp_sel_clr[pin];
-	if (freq) {
-		if (chan == 1)
-			tssdp |= ts_sdp_sel_fc1[pin];
-		else
-			tssdp |= ts_sdp_sel_fc0[pin];
-	} else {
-		if (chan == 1)
-			tssdp |= ts_sdp_sel_tt1[pin];
-		else
-			tssdp |= ts_sdp_sel_tt0[pin];
-	}
+	if (freq)
+		tssdp |= (chan == 1) ? ts_sdp_sel_fc1[pin] : ts_sdp_sel_fc0[pin];
+	else
+		tssdp |= (chan == 1) ? ts_sdp_sel_tt1[pin] : ts_sdp_sel_tt0[pin];
 	tssdp |= ts_sdp_en[pin];
 
 	E1000_WRITE_REG(hw, E1000_TSSDP, tssdp);

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -514,7 +514,7 @@ static void igb_pin_extts(struct igb_adapter *igb, int chan, int pin)
 	wr32(E1000_CTRL_EXT, ctrl_ext);
 }
 
-static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin)
+static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin, int freq)
 {
 	static const u32 aux0_sel_sdp[IGB_N_SDP] = {
 		AUX0_SEL_SDP0, AUX0_SEL_SDP1, AUX0_SEL_SDP2, AUX0_SEL_SDP3,
@@ -532,6 +532,14 @@ static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin)
 	static const u32 ts_sdp_sel_tt1[IGB_N_SDP] = {
 		TS_SDP0_SEL_TT1, TS_SDP1_SEL_TT1,
 		TS_SDP2_SEL_TT1, TS_SDP3_SEL_TT1,
+	};
+	static const u32 ts_sdp_sel_fc0[IGB_N_SDP] = {
+		TS_SDP0_SEL_FC0, TS_SDP1_SEL_FC0,
+		TS_SDP2_SEL_FC0, TS_SDP3_SEL_FC0,
+	};
+	static const u32 ts_sdp_sel_fc1[IGB_N_SDP] = {
+		TS_SDP0_SEL_FC1, TS_SDP1_SEL_FC1,
+		TS_SDP2_SEL_FC1, TS_SDP3_SEL_FC1,
 	};
 	static const u32 ts_sdp_sel_clr[IGB_N_SDP] = {
 		TS_SDP0_SEL_FC1, TS_SDP1_SEL_FC1,
@@ -554,11 +562,17 @@ static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin)
 		tssdp &= ~AUX1_TS_SDP_EN;
 
 	tssdp &= ~ts_sdp_sel_clr[pin];
-	if (chan == 1)
-		tssdp |= ts_sdp_sel_tt1[pin];
-	else
-		tssdp |= ts_sdp_sel_tt0[pin];
-
+	if (freq) {
+		if (chan == 1)
+			tssdp |= ts_sdp_sel_fc1[pin];
+		else
+			tssdp |= ts_sdp_sel_fc0[pin];
+	} else {
+		if (chan == 1)
+			tssdp |= ts_sdp_sel_tt1[pin];
+		else
+			tssdp |= ts_sdp_sel_tt0[pin];
+	}
 	tssdp |= ts_sdp_en[pin];
 
 	wr32(E1000_TSSDP, tssdp);
@@ -572,10 +586,10 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 	struct igb_adapter *igb =
 		container_of(ptp, struct igb_adapter, ptp_caps);
 	struct e1000_hw *hw = &igb->hw;
-	u32 tsauxc, tsim, tsauxc_mask, tsim_mask, trgttiml, trgttimh;
+	u32 tsauxc, tsim, tsauxc_mask, tsim_mask, trgttiml, trgttimh, freqout;
 	unsigned long flags;
 	struct timespec ts;
-	int pin = -1;
+	int use_freq = 0, pin = -1;
 	s64 ns;
 
 	switch (rq->type) {
@@ -620,40 +634,58 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 		ts.tv_nsec = rq->perout.period.nsec;
 		ns = timespec_to_ns(&ts);
 		ns = ns >> 1;
-		if (on && ns < 500000LL) {
-			/* 2k interrupts per second is an awful lot. */
-			return -EINVAL;
+		if (on && ns <= 70000000LL) {
+			if (ns < 8LL)
+				return -EINVAL;
+			use_freq = 1;
 		}
 		ts = ns_to_timespec(ns);
 		if (rq->perout.index == 1) {
-			tsauxc_mask = TSAUXC_EN_TT1;
-			tsim_mask = TSINTR_TT1;
+			if (use_freq) {
+				tsauxc_mask = TSAUXC_EN_CLK1 | TSAUXC_ST1;
+				tsim_mask = 0;
+			} else {
+				tsauxc_mask = TSAUXC_EN_TT1;
+				tsim_mask = TSINTR_TT1;
+			}
 			trgttiml = E1000_TRGTTIML1;
 			trgttimh = E1000_TRGTTIMH1;
+			freqout = E1000_FREQOUT1;
 		} else {
-			tsauxc_mask = TSAUXC_EN_TT0;
-			tsim_mask = TSINTR_TT0;
+			if (use_freq) {
+				tsauxc_mask = TSAUXC_EN_CLK0 | TSAUXC_ST0;
+				tsim_mask = 0;
+			} else {
+				tsauxc_mask = TSAUXC_EN_TT0;
+				tsim_mask = TSINTR_TT0;
+			}
 			trgttiml = E1000_TRGTTIML0;
 			trgttimh = E1000_TRGTTIMH0;
+			freqout = E1000_FREQOUT0;
 		}
 		spin_lock_irqsave(&igb->tmreg_lock, flags);
 		tsauxc = rd32(E1000_TSAUXC);
 		tsim = rd32(E1000_TSIM);
+		if (rq->perout.index == 1) {
+			tsauxc &= ~(TSAUXC_EN_TT1 | TSAUXC_EN_CLK1 | TSAUXC_ST1);
+			tsim &= ~TSINTR_TT1;
+		} else {
+			tsauxc &= ~(TSAUXC_EN_TT0 | TSAUXC_EN_CLK0 | TSAUXC_ST0);
+			tsim &= ~TSINTR_TT0;
+		}
 		if (on) {
 			int i = rq->perout.index;
-
-			igb_pin_perout(igb, i, pin);
+			igb_pin_perout(igb, i, pin, use_freq);
 			igb->perout[i].start.tv_sec = rq->perout.start.sec;
 			igb->perout[i].start.tv_nsec = rq->perout.start.nsec;
 			igb->perout[i].period.tv_sec = ts.tv_sec;
 			igb->perout[i].period.tv_nsec = ts.tv_nsec;
 			wr32(trgttimh, rq->perout.start.sec);
 			wr32(trgttiml, rq->perout.start.nsec);
+			if (use_freq)
+				wr32(freqout, ns);
 			tsauxc |= tsauxc_mask;
 			tsim |= tsim_mask;
-		} else {
-			tsauxc &= ~tsauxc_mask;
-			tsim &= ~tsim_mask;
 		}
 		wr32(E1000_TSAUXC, tsauxc);
 		wr32(E1000_TSIM, tsim);

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -474,7 +474,7 @@ static int igb_ptp_settime_i210(struct ptp_clock_info *ptp,
 static void igb_pin_direction(int pin, int input, u32 *ctrl, u32 *ctrl_ext)
 {
 	u32 *ptr = pin < 2 ? ctrl : ctrl_ext;
-	u32 mask[IGB_N_SDP] = {
+	static const u32 mask[IGB_N_SDP] = {
 		E1000_CTRL_SDP0_DIR,
 		E1000_CTRL_SDP1_DIR,
 		E1000_CTRL_EXT_SDP2_DIR,
@@ -489,16 +489,16 @@ static void igb_pin_direction(int pin, int input, u32 *ctrl, u32 *ctrl_ext)
 
 static void igb_pin_extts(struct igb_adapter *igb, int chan, int pin)
 {
-	struct e1000_hw *hw = &igb->hw;
-	u32 aux0_sel_sdp[IGB_N_SDP] = {
+	static const u32 aux0_sel_sdp[IGB_N_SDP] = {
 		AUX0_SEL_SDP0, AUX0_SEL_SDP1, AUX0_SEL_SDP2, AUX0_SEL_SDP3,
 	};
-	u32 aux1_sel_sdp[IGB_N_SDP] = {
+	static const u32 aux1_sel_sdp[IGB_N_SDP] = {
 		AUX1_SEL_SDP0, AUX1_SEL_SDP1, AUX1_SEL_SDP2, AUX1_SEL_SDP3,
 	};
-	u32 ts_sdp_en[IGB_N_SDP] = {
+	static const u32 ts_sdp_en[IGB_N_SDP] = {
 		TS_SDP0_EN, TS_SDP1_EN, TS_SDP2_EN, TS_SDP3_EN,
 	};
+	struct e1000_hw *hw = &igb->hw;
 	u32 ctrl, ctrl_ext, tssdp = 0;
 
 	ctrl = rd32(E1000_CTRL);
@@ -525,28 +525,28 @@ static void igb_pin_extts(struct igb_adapter *igb, int chan, int pin)
 
 static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin)
 {
-	struct e1000_hw *hw = &igb->hw;
-	u32 aux0_sel_sdp[IGB_N_SDP] = {
+	static const u32 aux0_sel_sdp[IGB_N_SDP] = {
 		AUX0_SEL_SDP0, AUX0_SEL_SDP1, AUX0_SEL_SDP2, AUX0_SEL_SDP3,
 	};
-	u32 aux1_sel_sdp[IGB_N_SDP] = {
+	static const u32 aux1_sel_sdp[IGB_N_SDP] = {
 		AUX1_SEL_SDP0, AUX1_SEL_SDP1, AUX1_SEL_SDP2, AUX1_SEL_SDP3,
 	};
-	u32 ts_sdp_en[IGB_N_SDP] = {
+	static const u32 ts_sdp_en[IGB_N_SDP] = {
 		TS_SDP0_EN, TS_SDP1_EN, TS_SDP2_EN, TS_SDP3_EN,
 	};
-	u32 ts_sdp_sel_tt0[IGB_N_SDP] = {
+	static const u32 ts_sdp_sel_tt0[IGB_N_SDP] = {
 		TS_SDP0_SEL_TT0, TS_SDP1_SEL_TT0,
 		TS_SDP2_SEL_TT0, TS_SDP3_SEL_TT0,
 	};
-	u32 ts_sdp_sel_tt1[IGB_N_SDP] = {
+	static const u32 ts_sdp_sel_tt1[IGB_N_SDP] = {
 		TS_SDP0_SEL_TT1, TS_SDP1_SEL_TT1,
 		TS_SDP2_SEL_TT1, TS_SDP3_SEL_TT1,
 	};
-	u32 ts_sdp_sel_clr[IGB_N_SDP] = {
+	static const u32 ts_sdp_sel_clr[IGB_N_SDP] = {
 		TS_SDP0_SEL_FC1, TS_SDP1_SEL_FC1,
 		TS_SDP2_SEL_FC1, TS_SDP3_SEL_FC1,
 	};
+	struct e1000_hw *hw = &igb->hw;
 	u32 ctrl, ctrl_ext, tssdp = 0;
 
 	ctrl = rd32(E1000_CTRL);

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -492,9 +492,9 @@ static void igb_pin_extts(struct igb_adapter *igb, int chan, int pin)
 	struct e1000_hw *hw = &igb->hw;
 	u32 ctrl, ctrl_ext, tssdp = 0;
 
-	ctrl = rd32(E1000_CTRL);
-	ctrl_ext = rd32(E1000_CTRL_EXT);
-	tssdp = rd32(E1000_TSSDP);
+	ctrl = E1000_READ_REG(hw, E1000_CTRL);
+	ctrl_ext = E1000_READ_REG(hw, E1000_CTRL_EXT);
+	tssdp = E1000_READ_REG(hw, E1000_TSSDP);
 
 	igb_pin_direction(pin, 1, &ctrl, &ctrl_ext);
 
@@ -509,9 +509,9 @@ static void igb_pin_extts(struct igb_adapter *igb, int chan, int pin)
 		tssdp |= aux0_sel_sdp[pin] | AUX0_TS_SDP_EN;
 	}
 
-	wr32(E1000_TSSDP, tssdp);
-	wr32(E1000_CTRL, ctrl);
-	wr32(E1000_CTRL_EXT, ctrl_ext);
+	E1000_WRITE_REG(hw, E1000_TSSDP, tssdp);
+	E1000_WRITE_REG(hw, E1000_CTRL, ctrl);
+	E1000_WRITE_REG(hw, E1000_CTRL_EXT, ctrl_ext);
 }
 
 static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin, int freq)
@@ -548,9 +548,9 @@ static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin, int freq)
 	struct e1000_hw *hw = &igb->hw;
 	u32 ctrl, ctrl_ext, tssdp = 0;
 
-	ctrl = rd32(E1000_CTRL);
-	ctrl_ext = rd32(E1000_CTRL_EXT);
-	tssdp = rd32(E1000_TSSDP);
+	ctrl = E1000_READ_REG(hw, E1000_CTRL);
+	ctrl_ext = E1000_READ_REG(hw, E1000_CTRL_EXT);
+	tssdp = E1000_READ_REG(hw, E1000_TSSDP);
 
 	igb_pin_direction(pin, 0, &ctrl, &ctrl_ext);
 
@@ -575,9 +575,9 @@ static void igb_pin_perout(struct igb_adapter *igb, int chan, int pin, int freq)
 	}
 	tssdp |= ts_sdp_en[pin];
 
-	wr32(E1000_TSSDP, tssdp);
-	wr32(E1000_CTRL, ctrl);
-	wr32(E1000_CTRL_EXT, ctrl_ext);
+	E1000_WRITE_REG(hw, E1000_TSSDP, tssdp);
+	E1000_WRITE_REG(hw, E1000_CTRL, ctrl);
+	E1000_WRITE_REG(hw, E1000_CTRL_EXT, ctrl_ext);
 }
 
 static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
@@ -608,8 +608,8 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 			tsim_mask = TSINTR_AUTT0;
 		}
 		spin_lock_irqsave(&igb->tmreg_lock, flags);
-		tsauxc = rd32(E1000_TSAUXC);
-		tsim = rd32(E1000_TSIM);
+		tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
+		tsim = E1000_READ_REG(hw, E1000_TSIM);
 		if (on) {
 			igb_pin_extts(igb, rq->extts.index, pin);
 			tsauxc |= tsauxc_mask;
@@ -618,8 +618,8 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 			tsauxc &= ~tsauxc_mask;
 			tsim &= ~tsim_mask;
 		}
-		wr32(E1000_TSAUXC, tsauxc);
-		wr32(E1000_TSIM, tsim);
+		E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc);
+		E1000_WRITE_REG(hw, E1000_TSIM, tsim);
 		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
 		return 0;
 
@@ -665,8 +665,8 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 			freqout = E1000_FREQOUT0;
 		}
 		spin_lock_irqsave(&igb->tmreg_lock, flags);
-		tsauxc = rd32(E1000_TSAUXC);
-		tsim = rd32(E1000_TSIM);
+		tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
+		tsim = E1000_READ_REG(hw, E1000_TSIM);
 		if (rq->perout.index == 1) {
 			tsauxc &= ~(TSAUXC_EN_TT1 | TSAUXC_EN_CLK1 | TSAUXC_ST1);
 			tsim &= ~TSINTR_TT1;
@@ -681,26 +681,26 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 			igb->perout[i].start.tv_nsec = rq->perout.start.nsec;
 			igb->perout[i].period.tv_sec = ts.tv_sec;
 			igb->perout[i].period.tv_nsec = ts.tv_nsec;
-			wr32(trgttimh, rq->perout.start.sec);
-			wr32(trgttiml, rq->perout.start.nsec);
+			E1000_WRITE_REG(hw, trgttimh, rq->perout.start.sec);
+			E1000_WRITE_REG(hw, trgttiml, rq->perout.start.nsec);
 			if (use_freq)
-				wr32(freqout, ns);
+				E1000_WRITE_REG(hw, freqout, ns);
 			tsauxc |= tsauxc_mask;
 			tsim |= tsim_mask;
 		}
-		wr32(E1000_TSAUXC, tsauxc);
-		wr32(E1000_TSIM, tsim);
+		E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc);
+		E1000_WRITE_REG(hw, E1000_TSIM, tsim);
 		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
 		return 0;
 
 	case PTP_CLK_REQ_PPS:
 		spin_lock_irqsave(&igb->tmreg_lock, flags);
-		tsim = rd32(E1000_TSIM);
+		tsim = E1000_READ_REG(hw, E1000_TSIM);
 		if (on)
 			tsim |= TSINTR_SYS_WRAP;
 		else
 			tsim &= ~TSINTR_SYS_WRAP;
-		wr32(E1000_TSIM, tsim);
+		E1000_WRITE_REG(hw, E1000_TSIM, tsim);
 		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
 		return 0;
 	}
@@ -1323,7 +1323,7 @@ void igb_ptp_reset(struct igb_adapter *adapter)
 	case e1000_i210:
 	case e1000_i211:
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
-		wr32(E1000_TSSDP, 0x0);
+		E1000_WRITE_REG(hw, E1000_TSSDP, 0x0);
 		E1000_WRITE_REG(hw, E1000_TSIM, TSYNC_INTERRUPTS);
 		E1000_WRITE_REG(hw, E1000_IMS, E1000_IMS_TS);
 		break;

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -584,7 +584,7 @@ static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
 	u32 tsauxc, tsim, tsauxc_mask, tsim_mask, trgttiml, trgttimh;
 	unsigned long flags;
 	struct timespec ts;
-	int pin;
+	int pin = -1;
 	s64 ns;
 
 	switch (rq->type) {

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -471,6 +471,34 @@ static int igb_ptp_settime_i210(struct ptp_clock_info *ptp,
 }
 
 #endif
+static int igb_ptp_feature_enable_i210(struct ptp_clock_info *ptp,
+				       struct ptp_clock_request *rq, int on)
+{
+	struct igb_adapter *igb =
+		container_of(ptp, struct igb_adapter, ptp_caps);
+	struct e1000_hw *hw = &igb->hw;
+	unsigned long flags;
+	u32 tsim;
+
+	switch (rq->type) {
+	case PTP_CLK_REQ_PPS:
+		spin_lock_irqsave(&igb->tmreg_lock, flags);
+		tsim = rd32(E1000_TSIM);
+		if (on)
+			tsim |= TSINTR_SYS_WRAP;
+		else
+			tsim &= ~TSINTR_SYS_WRAP;
+		wr32(E1000_TSIM, tsim);
+		spin_unlock_irqrestore(&igb->tmreg_lock, flags);
+		return 0;
+
+	default:
+		break;
+	}
+
+	return -EOPNOTSUPP;
+}
+
 static int igb_ptp_feature_enable(struct ptp_clock_info *ptp,
 				  struct ptp_clock_request *rq, int on)
 {
@@ -930,7 +958,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		adapter->ptp_caps.owner = THIS_MODULE;
 		adapter->ptp_caps.max_adj = 62499999;
 		adapter->ptp_caps.n_ext_ts = 0;
-		adapter->ptp_caps.pps = 0;
+		adapter->ptp_caps.pps = 1;
 		adapter->ptp_caps.adjfreq = igb_ptp_adjfreq_82580;
 		adapter->ptp_caps.adjtime = igb_ptp_adjtime_i210;
 #ifdef HAVE_PTP_CLOCK_INFO_GETTIME64
@@ -940,7 +968,7 @@ void igb_ptp_init(struct igb_adapter *adapter)
 		adapter->ptp_caps.gettime = igb_ptp_gettime_i210;
 		adapter->ptp_caps.settime = igb_ptp_settime_i210;
 #endif
-		adapter->ptp_caps.enable = igb_ptp_feature_enable;
+		adapter->ptp_caps.enable = igb_ptp_feature_enable_i210;
 		/* Enable the timer functions by clearing bit 31. */
 		E1000_WRITE_REG(hw, E1000_TSAUXC, 0x0);
 		break;

--- a/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
@@ -297,11 +297,8 @@ static int openavbTLCfgCallback(void *user, const char *tlSection, const char *n
 		}
 	}
 	else if (MATCH(name, "ifname")) {
-		if_info_t ifinfo;
-		if (openavbCheckInterface(value, &ifinfo)) {
-			strncpy(pCfg->ifname, value, IFNAMSIZ - 1);
-			valOK = TRUE;
-		}
+		strncpy(pCfg->ifname, value, IFNAMSIZ - 1);
+		valOK = TRUE;
 	}
 	else if (MATCH(name, "vlan_id")) {
 		errno = 0;
@@ -405,6 +402,13 @@ EXTERN_DLL_EXPORT bool openavbTLReadIniFileOsal(tl_handle_t TLhandle, const char
 	parseIniData.pNVCfg = pNVCfg;
 
 	int result = ini_parse(fileName, openavbTLCfgCallback, &parseIniData);
+	if (result == 0) {
+		if_info_t ifinfo;
+		if (!openavbCheckInterface(&parseIniData.pCfg->ifname, &ifinfo)) {
+			AVB_LOGF_ERROR("Invalid value: name=%s, value=%s", "ifname", parseIniData.pCfg->ifname);
+			return FALSE;
+		}
+	}
 	if (result < 0) {
 		AVB_LOGF_ERROR("Couldn't parse INI file: %s", fileName);
 		return FALSE;

--- a/lib/avtp_pipeline/tl/openavb_talker.c
+++ b/lib/avtp_pipeline/tl/openavb_talker.c
@@ -170,7 +170,7 @@ void talkerStopStream(tl_state_t *pTLState)
 		openavbTalkerGetStat(pTLState, TL_STAT_TX_FRAMES),
 		openavbTalkerGetStat(pTLState, TL_STAT_TX_LATE),
 		openavbTalkerGetStat(pTLState, TL_STAT_TX_BYTES),
-		openavbRawsockGetTXOutOfBuffers(rawsock)
+		rawsock ? openavbRawsockGetTXOutOfBuffers(rawsock) : 0
 		);
 
 	if (pTLState->bStreaming) {


### PR DESCRIPTION
In mainline kernel igb driver, I210 auxiliary PTP Hardware Clock (PHC) functions have been added since kernel version 4.0.

The igb driver auxiliary PHC functions relevant code changes are ported to Open AVB igb_avb driver so that two of the possible functions, namely time stamping external events, and periodic output signals, are available to use.